### PR TITLE
Clear google-chrome's LD_LIBRARY_PATH before spawning the player

### DIFF
--- a/acestream_launcher/player.py
+++ b/acestream_launcher/player.py
@@ -30,8 +30,16 @@ class PlayerHandler(Observable):
       self.emit('terminated')
 
   def _start_process(self, *args, **kwargs):
+    env = os.environ.copy()
+    ld_paths = env.get("LD_LIBRARY_PATH", "").split(":")
+    if len(ld_paths) > 0:
+      for path in list(ld_paths):
+        if os.path.isfile(os.path.join(path, "chrome")) and os.path.isfile(os.path.join(path, "libvulkan.so.1")):
+          ld_paths.remove(path)
+      env["LD_LIBRARY_PATH"] = ":".join(ld_paths)
+
     try:
-      self.process = subprocess.Popen(args, preexec_fn=os.setsid, **kwargs)
+      self.process = subprocess.Popen(args, env=env, preexec_fn=os.setsid, **kwargs)
       self.emit('started')
       self.process.communicate()
 


### PR DESCRIPTION
Google Chrome ships with bundled libvulkan.so.1 and links to it by
setting LD_LIBRARY_PATH in the startup script.

When acestream-launcher is invoked from chrome through the
acestream:// protocol, the environment variables are passed in
and eventually passed to the player.

In fedora + rpmfusion, when mpv is spawned it fails to link because
it attempts to link against google's build of libvulkan instead of
the system provided library.

---
This is hacky but i think it's fine to fix the issue in acestream-launcher even though it's not its fault, since it's the bridge between the browser and mpv